### PR TITLE
Remove deprecated babel 5 options

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,2 @@
 {
-  "stage": 0,
-  "blacklist": ["strict"]
 }


### PR DESCRIPTION
The old babel 5 options in the .babelrc are causing webpack to spit out teh following error:

```
ERROR in ./~/react-as-event-mixin/src/index.js
Module build failed: ReferenceError: [BABEL] /Users/terrymorgan/Development/web_projects/timelapse/src/TimelapsePlayer/node_modules/react-as-event-mixin/src/index.js: Using removed Babel 5 option: /Users/terrymorgan/Development/web_projects/timelapse/src/TimelapsePlayer/node_modules/react-as-event-mixin/.babelrc.blacklist - Put the specific transforms you want in the `plugins` option
    at Logger.error (/Users/terrymorgan/Development/web_projects/timelapse/src/TimelapsePlayer/node_modules/babel-core/lib/transformation/file/logger.js:39:11)
    at OptionManager.mergeOptions (/Users/terrymorgan/Development/web_projects/timelapse/src/TimelapsePlayer/node_modules/babel-core/lib/transformation/file/options/option-manager.js:265:20)
    at OptionManager.addConfig (/Users/terrymorgan/Development/web_projects/timelapse/src/TimelapsePlayer/node_modules/babel-core/lib/transformation/file/options/option-manager.js:207:10)
    at OptionManager.findConfigs (/Users/terrymorgan/Development/web_projects/timelapse/src/TimelapsePlayer/node_modules/babel-core/lib/transformation/file/options/option-manager.js:413:16)
    at OptionManager.init (/Users/terrymorgan/Development/web_projects/timelapse/src/TimelapsePlayer/node_modules/babel-core/lib/transformation/file/options/option-manager.js:461:12)
    at File.initOptions (/Users/terrymorgan/Development/web_projects/timelapse/src/TimelapsePlayer/node_modules/babel-core/lib/transformation/file/index.js:194:75)
    at new File (/Users/terrymorgan/Development/web_projects/timelapse/src/TimelapsePlayer/node_modules/babel-core/lib/transformation/file/index.js:123:22)
    at Pipeline.transform (/Users/terrymorgan/Development/web_projects/timelapse/src/TimelapsePlayer/node_modules/babel-core/lib/transformation/pipeline.js:45:16)
    at transpile (/Users/terrymorgan/Development/web_projects/timelapse/src/TimelapsePlayer/node_modules/babel-loader/index.js:14:22)
    at /Users/terrymorgan/Development/web_projects/timelapse/src/TimelapsePlayer/node_modules/babel-loader/lib/fs-cache.js:145:18
    at ReadFileContext.callback (/Users/terrymorgan/Development/web_projects/timelapse/src/TimelapsePlayer/node_modules/babel-loader/lib/fs-cache.js:28:23)
    at FSReqWrap.readFileAfterOpen [as oncomplete] (fs.js:303:13)
 @ ./Slides.js 35:17-48
```

The stage & blacklist options have been removed and replaced with plugins.
